### PR TITLE
pairs.csvと画像ファイルの対応付け

### DIFF
--- a/dobble_maker.py
+++ b/dobble_maker.py
@@ -1393,12 +1393,13 @@ def save_card_list_to_csv(
         image_names:
             シンボル画像名. image_pathsの拡張子を除くファイル名をキー、表示名をバリューとする.
             指定時は必ず image_paths も指定すること.
-
-    Raises:
-        Exception: _description_
     """
     if image_names is not None and image_paths is None:
         raise Exception("image_names 指定時は image_paths を必ず指定する")
+
+    if image_names is not None:
+        # image_namesにある"\n"は改行ではなくそのまま文字列として出力できるように修正
+        image_names = {k: v.replace("\n", "\\n") for k, v in image_names.items()}
 
     # 各カードのIDのcsv
     _path = os.path.join(output_dir, "pairs.csv")
@@ -1408,18 +1409,22 @@ def save_card_list_to_csv(
     if image_paths is not None:
         _path = os.path.join(output_dir, "images.csv")
         with open(_path, "w", encoding="utf_8_sig") as f:
-            f.write("ID,画像ファイル")
+            # "画像名"には任意の文字が入る可能性があるためエスケープできるようにcsv.writerを使う
+            writer = csv.writer(f, lineterminator="\n")
+
+            header = ["ID", "画像ファイル"]
             if image_names is not None:
-                f.write(",画像名")
-            f.write("\n")
+                header.append("画像名")
+            writer.writerow(header)
+
             for i in range(len(image_paths)):
                 img_path = image_paths[i]
-                f.write(f"{i},{img_path}")
+                row = [str(i), img_path]
                 if image_names is not None:
                     img_base = os.path.splitext(os.path.basename(img_path))[0]
                     img_name = image_names.get(img_base, "")
-                    f.write(f",{img_name}")
-                f.write("\n")
+                    row.append(img_name)
+                writer.writerow(row)
 
     # 各カードの画像名のcsv
     if image_paths is not None:
@@ -1430,8 +1435,10 @@ def save_card_list_to_csv(
             id_to_name: dict[int, str] = {i: image_names.get(name, "") for i, name in id_to_base.items()}
 
         _path = os.path.join(output_dir, "card_names.csv")
-        tbl = [[id_to_name[id] for id in row] for row in pairs]
-        np.savetxt(_path, tbl, fmt="%s", delimiter=",", encoding="utf_8_sig")
+        rows = [[id_to_name[id] for id in row] for row in pairs]
+        with open(_path, "w", encoding="utf_8_sig") as f:
+            writer = csv.writer(f, lineterminator="\n")
+            writer.writerows(rows)
 
     return
 

--- a/dobble_maker.py
+++ b/dobble_maker.py
@@ -1403,28 +1403,34 @@ def save_card_list_to_csv(
 
     # 各カードのIDのcsv
     _path = os.path.join(output_dir, "pairs.csv")
-    np.savetxt(_path, pairs, delimiter=",", fmt="%d")
+    try:
+        np.savetxt(_path, pairs, delimiter=",", fmt="%d")
+    except Exception as e:
+        raise Exception(f"{_path} の保存に失敗") from e
 
     # 使用された画像ファイル一覧のcsv
     if image_paths is not None:
         _path = os.path.join(output_dir, "images.csv")
-        with open(_path, "w", encoding="utf_8_sig") as f:
-            # "画像名"には任意の文字が入る可能性があるためエスケープできるようにcsv.writerを使う
-            writer = csv.writer(f, lineterminator="\n")
+        try:
+            with open(_path, "w", encoding="utf_8_sig") as f:
+                # "画像名"には任意の文字が入る可能性があるためエスケープできるようにcsv.writerを使う
+                writer = csv.writer(f, lineterminator="\n")
 
-            header = ["ID", "画像ファイル"]
-            if image_names is not None:
-                header.append("画像名")
-            writer.writerow(header)
-
-            for i in range(len(image_paths)):
-                img_path = image_paths[i]
-                row = [str(i), img_path]
+                header = ["ID", "画像ファイル"]
                 if image_names is not None:
-                    img_base = os.path.splitext(os.path.basename(img_path))[0]
-                    img_name = image_names.get(img_base, "")
-                    row.append(img_name)
-                writer.writerow(row)
+                    header.append("画像名")
+                writer.writerow(header)
+
+                for i in range(len(image_paths)):
+                    img_path = image_paths[i]
+                    row = [str(i), img_path]
+                    if image_names is not None:
+                        img_base = os.path.splitext(os.path.basename(img_path))[0]
+                        img_name = image_names.get(img_base, "")
+                        row.append(img_name)
+                    writer.writerow(row)
+        except Exception as e:
+            raise Exception(f"{_path} の保存に失敗") from e
 
     # 各カードの画像名のcsv
     if image_paths is not None:
@@ -1436,9 +1442,12 @@ def save_card_list_to_csv(
 
         _path = os.path.join(output_dir, "card_names.csv")
         rows = [[id_to_name[id] for id in row] for row in pairs]
-        with open(_path, "w", encoding="utf_8_sig") as f:
-            writer = csv.writer(f, lineterminator="\n")
-            writer.writerows(rows)
+        try:
+            with open(_path, "w", encoding="utf_8_sig") as f:
+                writer = csv.writer(f, lineterminator="\n")
+                writer.writerows(rows)
+        except Exception as e:
+            raise Exception(f"{_path} の保存に失敗") from e
 
     return
 

--- a/dobble_maker.py
+++ b/dobble_maker.py
@@ -1375,6 +1375,67 @@ def sort_images_by_image_list(
     return sorted_images, sorted_names
 
 
+def save_card_list_to_csv(
+    output_dir: str,
+    pairs: list[list[int]],
+    *,
+    image_paths: list[str] | None = None,
+    image_names: dict[str, str] | None = None,
+):
+    """カード毎のID, 画像ファイル一覧, カード毎の画像ファイル, のcsvをそれぞれ出力
+
+    Args:
+        output_dir: 出力先ディレクトリ
+        pairs: 各カードに記載するシンボル番号
+        image_paths:
+            シンボル画像ファイルパス.
+            pairsのシンボル番号に対応するインデックスで格納されていること.
+        image_names:
+            シンボル画像名. image_pathsの拡張子を除くファイル名をキー、表示名をバリューとする.
+            指定時は必ず image_paths も指定すること.
+
+    Raises:
+        Exception: _description_
+    """
+    if image_names is not None and image_paths is None:
+        raise Exception("image_names 指定時は image_paths を必ず指定する")
+
+    # 各カードのIDのcsv
+    _path = os.path.join(output_dir, "card_ids.csv")
+    np.savetxt(_path, pairs, delimiter=",", fmt="%d")
+
+    # 使用された画像ファイル一覧のcsv
+    if image_paths is not None:
+        _path = os.path.join(output_dir, "files.csv")
+        with open(_path, "w", encoding="utf_8_sig") as f:
+            f.write("ID,画像ファイル")
+            if image_names is not None:
+                f.write(",画像名")
+            f.write("\n")
+            for i in range(len(image_paths)):
+                img_path = image_paths[i]
+                f.write(f"{i},{img_path}")
+                if image_names is not None:
+                    img_base = os.path.splitext(os.path.basename(img_path))[0]
+                    img_name = image_names.get(img_base, "")
+                    f.write(f",{img_name}")
+                f.write("\n")
+
+    # 各カードの画像名のcsv
+    if image_paths is not None:
+        id_to_base: dict[int, str] = {i: os.path.splitext(os.path.basename(x))[0] for i, x in enumerate(image_paths)}
+        if image_names is None:
+            id_to_name = id_to_base
+        else:
+            id_to_name: dict[int, str] = {i: image_names.get(name, "") for i, name in id_to_base.items()}
+
+        _path = os.path.join(output_dir, "card_names.csv")
+        tbl = [[id_to_name[id] for id in row] for row in pairs]
+        np.savetxt(_path, tbl, fmt="%s", delimiter=",", encoding="utf_8_sig")
+
+    return
+
+
 def main():
     # ============
     # パラメータ設定
@@ -1454,6 +1515,7 @@ def main():
         card_images.append(card_img)
 
     # 画像リストファイルの指定があれば画像リストカード画像を作成
+    image_names: None | dict[str, str] = None
     if image_list_path is not None:
         image_names = load_image_list(image_list_path)
         sorted_images, sorted_names = sort_images_by_image_list(
@@ -1474,6 +1536,9 @@ def main():
             path = output_dir + os.sep + f"thumbnail_{i}.png"
             cv2.imwrite(path, card)
             card_images.append(card)
+
+    # カード、シンボル画像に関する情報をcsv出力
+    save_card_list_to_csv(output_dir, pairs, image_paths=image_paths, image_names=image_names)
 
     # 各画像をA4 300 DPIに配置しPDF化
     images_to_pdf(

--- a/dobble_maker.py
+++ b/dobble_maker.py
@@ -1401,12 +1401,12 @@ def save_card_list_to_csv(
         raise Exception("image_names 指定時は image_paths を必ず指定する")
 
     # 各カードのIDのcsv
-    _path = os.path.join(output_dir, "card_ids.csv")
+    _path = os.path.join(output_dir, "pairs.csv")
     np.savetxt(_path, pairs, delimiter=",", fmt="%d")
 
     # 使用された画像ファイル一覧のcsv
     if image_paths is not None:
-        _path = os.path.join(output_dir, "files.csv")
+        _path = os.path.join(output_dir, "images.csv")
         with open(_path, "w", encoding="utf_8_sig") as f:
             f.write("ID,画像ファイル")
             if image_names is not None:

--- a/dobble_maker_gui.py
+++ b/dobble_maker_gui.py
@@ -510,7 +510,11 @@ class Application(tk.Frame):
             card_images.extend(thumb_card_images)
 
         # カード、シンボル画像に関する情報をcsv出力
-        save_card_list_to_csv(self._output_dir, pairs, image_paths=image_paths, image_names=image_names)
+        try:
+            save_card_list_to_csv(self._output_dir, pairs, image_paths=image_paths, image_names=image_names)
+        except Exception as e:
+            messagebox.showerror("エラー", str(e))
+            return
 
         # 各画像をA4 300 DPIに配置しPDF化
         images_to_pdf(


### PR DESCRIPTION
以下ファイルの出力を追加
* pairs.csv
  * カード毎のシンボル画像IDの組み合わせ表（GUI版では以前からあった）
* images.csv
  * 使用する画像ファイルパスとシンボル画像IDの対応表
* card_names.csv
  * カード毎の画像ファイル名の組み合わせ表
  * pairs.csvの各IDをimages.csvの画像名で置き換えたもの
    * 画像名は、画像リスト指定時はその画像名、未指定時は画像ファイルのベース名（＝拡張子を除くファイル名）となる